### PR TITLE
Fixed event shorthand deprecation issues

### DIFF
--- a/js/wpjobs_ajax.js
+++ b/js/wpjobs_ajax.js
@@ -1,6 +1,6 @@
 // JavaScript Document
-jQuery(document).ready(function($){
-	$("#form1").submit(function(){
+jQuery(function($){
+	$("#form1").on("submit", function(){
 		$('#wpjobs_loading').show();
 		$('#wpjobs_submit').attr('disabled', true);
 		data = $("#form1").serialize()+'&do=update_wpjobs_options&action=update_wpjobs_options&wpjobs_nonce='+wpjobs_vars.wpjobs_nonce;

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,10 @@
 === WP Jobs ===
-Contributors: 99robots, charliepatel, draftpress
+Contributors: 99robots, charliepatel, DraftPress
 Donate link: http://www.intensewp.com/wp-jobs/
 Tags: wp jobs, wordpress job listing plugin, wordpress jobs, resume cv attachment
 Requires at least: 4.5
-Tested up to: 5.5.1
-Stable tag: 2.3.1
+Tested up to: 5.7.2
+Stable tag: 2.3.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -63,6 +63,10 @@ Support
 == Screenshots ==
 
 == Changelog ==
+
+= 2.3.2 = 2021-06-11
+* Updated to make compatible with WordPress 5.7.2
+* Fixed event shorthand deprecation issues
 
 = 2.3.1 = 2020-09-14
 * Updated to make compatible with WordPress 5.5.1

--- a/wp-jobs.php
+++ b/wp-jobs.php
@@ -1,11 +1,11 @@
 <?php
 /*
   Plugin Name: WP Jobs
-  Plugin URI: https://draftpress.com/products
+  Plugin URI: https://draftpress.com/products/wp-jobs
   Description: Post jobs on your WordPress site. User can apply and attach resume/CV for the jobs.
-  Author: 99 Robots
-  Version: 2.3.1
-  Author URI: https://99robots.com/
+  Author: DraftPress
+  Version: 2.3.2
+  Author URI: https://draftpress.com/
   Text Domain: wp-jobs
   Domain Path: /languages
  */


### PR DESCRIPTION
### Made Compatible with WordPress 5.7.2
### Fixed event shorthand deprecation issue:

changed : `jQuery(document).ready(function($){`  
to:  `jQuery(function($){`

changed `.submit(function(){`  
to:  `.on( "submit", function(){`